### PR TITLE
Fix for crash when there is no gtk display

### DIFF
--- a/src/frontends/cmdline/loxodo.py
+++ b/src/frontends/cmdline/loxodo.py
@@ -221,8 +221,9 @@ Username : %s""" % (record.group.encode('utf-8', 'replace'),
 
             if pygtk is not None and gtk is not None:
                 cb = gtk.clipboard_get()
-                cb.set_text(record.passwd)
-                cb.store()
+                if cb is not None:
+                  cb.set_text(record.passwd)
+                  cb.store()
 
     def complete_show(self, text, line, begidx, endidx):
         if not text:


### PR DESCRIPTION
Reproduce the error by running over `ssh -x`

```
loxodo.py:223: GtkWarning: IA__gtk_clipboard_get_for_display: assertion 'display != NULL' failed
```

```
Traceback (most recent call last):
 ...
  File ".../loxodo/src/frontends/cmdline/loxodo.py", line 224, in do_show
    cb.set_text(record.passwd)
AttributeError: 'NoneType' object has no attribute 'set_text'
```
