### PR TITLE
Option for generating pronounceable passwords with pwgen

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -36,6 +36,7 @@ class Config(object):
         self.reduction = False
         self.search_notes = False
         self.search_passwd = False
+        self.use_pwgen = False
         self.alphabet = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_"
 
         self._fname = self.get_config_filename()
@@ -70,6 +71,10 @@ class Config(object):
             if self._parser.get("base", "search_passwd") == "True":
                 self.search_passwd = True
 
+        if self._parser.has_option("base", "use_pwgen"):
+            if self._parser.get("base", "use_pwgen") == "True":
+                self.use_pwgen = True
+
         if not os.path.exists(self._fname):
             self.save()
 
@@ -97,6 +102,7 @@ class Config(object):
         self._parser.set("base", "alphabetreduction", str(self.reduction))
         self._parser.set("base", "search_notes", str(self.search_notes))
         self._parser.set("base", "search_passwd", str(self.search_passwd))
+        self._parser.set("base", "use_pwgen", str(self.use_pwgen))
         filehandle = open(self._fname, 'w')
         self._parser.write(filehandle)
         filehandle.close()

--- a/src/frontends/wx/recordframe.py
+++ b/src/frontends/wx/recordframe.py
@@ -21,6 +21,7 @@ import os
 import platform
 import random
 import struct
+import subprocess
 import wx
 
 from .wxlocale import _
@@ -176,7 +177,7 @@ class RecordFrame(wx.Dialog):
             self._tc_passwd.SetFocus()
 
     def _on_generate_passwd(self, dummy):
-        _pwd = self.generate_password(alphabet=config.alphabet,pwd_length=config.pwlength,allow_reduction=config.reduction)
+        _pwd = self.generate_password(alphabet=config.alphabet,pwd_length=config.pwlength,allow_reduction=config.reduction,use_pwgen=config.use_pwgen)
         self._tc_passwd.SetValue(_pwd)
 
     @staticmethod
@@ -190,7 +191,21 @@ class RecordFrame(wx.Dialog):
             return retval
 
     @staticmethod
-    def generate_password(alphabet="abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_", pwd_length=8, allow_reduction=False):
+    def generate_password(alphabet="abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_",
+                          pwd_length=10, allow_reduction=False, use_pwgen=False):
+        if use_pwgen:
+            # use pwgen program to generate pronounceable passwords
+            options = '-cn'
+            if allow_reduction:
+                options += 'B'
+            stdout, stderr = subprocess.Popen(
+                    ['pwgen', options, str(pwd_length), '1'],
+                    stdout=subprocess.PIPE).communicate()
+            pwd = stdout.strip()
+            assert len(pwd) == pwd_length
+            return pwd
+
+
         # remove some easy-to-mistake characters
         if allow_reduction:
             for _chr in "0OjlI1":

--- a/src/frontends/wx/settings.py
+++ b/src/frontends/wx/settings.py
@@ -21,6 +21,7 @@ import os
 import platform
 import random
 import struct
+import subprocess
 import wx
 
 from .wxlocale import _
@@ -49,6 +50,13 @@ class Settings(wx.Dialog):
         self._sc_length = self._add_a_spincontrol(_sz_fields, _("Generated Password Length") + ":",4,128)
 
         _sz_main.Add(_sz_fields, 1, wx.EXPAND | wx.GROW)
+
+        try:
+            # Throws exception of pwgen is not installed
+            subprocess.Popen(['pwgen'], stdout=subprocess.PIPE).communicate()
+            self._cb_pwgen = self._add_a_checkbox(_sz_fields,_("Use pwgen to generate passwords") + ":")
+        except OSError:
+            self._cb_pwgen = None
 
         self._cb_reduction = self._add_a_checkbox(_sz_fields,_("Avoid easy to mistake chars") + ":")
 
@@ -115,6 +123,8 @@ class Settings(wx.Dialog):
         """
         Update fields from source
         """
+        if self._cb_pwgen:
+            self._cb_pwgen.SetValue(config.use_pwgen)
         self._sc_length.SetValue(config.pwlength)
         self._tc_alphabet.SetValue(config.alphabet)
         self._cb_reduction.SetValue(config.reduction)
@@ -125,6 +135,8 @@ class Settings(wx.Dialog):
         """
         Update source from fields
         """
+        if self._cb_pwgen:
+            config.use_pwgen = self._cb_pwgen.GetValue()
         config.pwlength = self._sc_length.GetValue()
         config.reduction = self._cb_reduction.GetValue()
         config.search_notes = self._search_notes.GetValue()


### PR DESCRIPTION
This commit adds an option in the settings dialog to generate passwords with the external program `pwgen` instead of the build-in algorithm.  This option is hidden if `pwgen` is not installed.  The default is disabled.

Pwgen passwords may be preferable because they are "pronounceable" and easier to copy by hand into things like phones.  As an example, pwgen passwords look like:

```
equeighiRoP6
phau5Cahs9ea
jaa8EiXie8Ai
ORecoh1ni4De
```

Loxodo (default) passwords look like:

```
Vb_iCBzGIvh0
_C5SfeMqAwda
t5Fsn2cVVSbK
1sbKNvakT_fQ
```
